### PR TITLE
Add bootstrap to layout page

### DIFF
--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -8,9 +8,22 @@
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     ></script>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN"
+      crossorigin="anonymous"
+    />
+
     <title>StudentCourseReview</title>
   </head>
   <body>
     {{{body}}}
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
+      crossorigin="anonymous"
+    ></script>
+
   </body>
 </html>


### PR DESCRIPTION
Added bootstrap through CDN links on the layout page. NPM also hosts bootstrap, but adding it with CDN links should 'just work'.