### PR TITLE
Add seed files

### DIFF
--- a/config/mongoConnection.js
+++ b/config/mongoConnection.js
@@ -5,6 +5,9 @@ const mongoConfig = settings.mongoConfig;
 let _connection = undefined;
 let _db = undefined;
 
+/**
+ * @returns {Promise<MongoClient>}
+ */
 export default async () => {
   if (!_connection) {
     _connection = await MongoClient.connect(mongoConfig.serverUrl);

--- a/config/seed/seed.js
+++ b/config/seed/seed.js
@@ -1,0 +1,42 @@
+import { universities, users } from "../mongoCollections.js";
+import getDb from "../mongoConnection.js";
+import bcrypt from "bcrypt";
+
+const usersCollection = await users();
+const universitiesCollection = await universities();
+
+usersCollection.drop();
+universitiesCollection.drop();
+
+console.info("🌱 Begin seeding database");
+
+await usersCollection.insertOne({
+  email: "admin@stevens.edu",
+  hashedPassword: bcrypt.hashSync("admin123", 10),
+  username: "admin",
+});
+
+await usersCollection.insertOne({
+  email: "student@stevens.edu",
+  hashedPassword: bcrypt.hashSync("student123", 10),
+  username: "student",
+});
+
+await universitiesCollection.insertOne({
+  name: "Stevens Institute of Technology",
+  location: "Hoboken, NJ",
+});
+
+await universitiesCollection.insertOne({
+  name: "Rutgers University",
+  location: "New Brunswick, NJ",
+});
+
+await universitiesCollection.insertOne({
+  name: "New Jersey Institute of Technology",
+  location: "Newark, NJ",
+});
+
+console.info("✅ Seeding complete");
+
+process.exit(0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "student-course-review",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "format": "prettier --write .",
     "lint": "prettier --check .",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "seed": "node ./config/seed/seed.js",
+    "postinstall": "npm run seed"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
This commit adds seeds for university and users table. An admin account and a student account are created as well as 3 colleges. More seed can be added here when we add courses, reviews, ratings.

The seed drops all of the collections, so it should not be used in production.